### PR TITLE
Fix Hebrew ready text

### DIFF
--- a/src/pimp-my-wolt.js
+++ b/src/pimp-my-wolt.js
@@ -12,7 +12,7 @@
   
   const texts = {
     suggestedGuestsText: getCurrentLangugue("Suggested people" , "אנשים שאולי ירצו להזמין איתך"),
-    readyText: getCurrentLangugue("Ready", "מוכן"),
+    readyText: getCurrentLangugue("Ready", "מוכנ/ה"),
     inviteAllInGroup: (groupName) => getCurrentLangugue(`Invite ${groupName}`, `הזמן את ${groupName}`),
     addGroup: getCurrentLangugue("Add Group" , "הוסף קבוצה"),
     wheelButtonTooltip: getCurrentLangugue("Don't know what to order yet?", "לא יודעים מה להזמין עדיין?"),


### PR DESCRIPTION
Seems that Hebrew text for "Ready" is changed

![image](https://github.com/user-attachments/assets/69a88677-9bba-49b5-a405-a3b1ca9fd47a)
